### PR TITLE
Add PDF opening functionality to telescope-zotero.nvim

### DIFF
--- a/lua/zotero/bib.lua
+++ b/lua/zotero/bib.lua
@@ -47,28 +47,19 @@ end
 M.entry_to_bib_entry = function(entry)
   local bib_entry = '@'
   local item = entry.value
-  local citekey = item.citekey
-  if not citekey then
-    citekey = item.citekey
-  end
-  bib_entry = bib_entry .. item.itemType .. '{' .. citekey .. ',\n'
+  local citekey = item.citekey or ''
+  bib_entry = bib_entry .. (item.itemType or '') .. '{' .. citekey .. ',\n'
   for k, v in pairs(item) do
     if k == 'creators' then
       bib_entry = bib_entry .. '  author = {'
       local author = ''
       for _, creator in ipairs(v) do
-        author = author .. creator.lastName .. ', ' .. creator.firstName .. ' and '
+        author = author .. (creator.lastName or '') .. ', ' .. (creator.firstName or '') .. ' and '
       end
       -- remove trailing ' and '
       author = string.sub(author, 1, -6)
       bib_entry = bib_entry .. author .. '},\n'
-    elseif k == 'citekey' then
-      -- do nothing
-      -- already in the header
-    elseif k == 'itemType' then
-      -- do nothing
-      -- already in the header
-    else
+    elseif k ~= 'citekey' and k ~= 'itemType' and k ~= 'attachment' and type(v) == 'string' then
       bib_entry = bib_entry .. '  ' .. k .. ' = {' .. v .. '},\n'
     end
   end

--- a/lua/zotero/database.lua
+++ b/lua/zotero/database.lua
@@ -75,7 +75,6 @@ function M.get_items()
     vim.notify_once('[zotero] could not query database.', vim.log.levels.WARN, {})
     return {}
   end
-
   local bbt_citekeys = {}
   for _, v in pairs(sql_bbt) do
     bbt_citekeys[v.itemKey] = v.citationKey
@@ -83,7 +82,7 @@ function M.get_items()
 
   for _, v in pairs(sql_items) do
     if raw_items[v.key] == nil then
-      raw_items[v.key] = { creators = {}, attachment = {} }
+      raw_items[v.key] = { creators = {}, attachment = {}, key = v.key }
     end
     raw_items[v.key][v.fieldName] = v.value
     raw_items[v.key].itemType = v.typeName

--- a/lua/zotero/database.lua
+++ b/lua/zotero/database.lua
@@ -34,7 +34,10 @@ local query_items = [[
       DISTINCT items.key, items.itemID,
       fields.fieldName,
       parentItemDataValues.value,
-      itemTypes.typeName
+      itemTypes.typeName,
+      itemAttachments.path AS attachment_path,
+      itemAttachments.contentType AS attachment_content_type,
+      itemAttachments.linkMode AS attachment_link_mode
     FROM
       items
       INNER JOIN itemData ON itemData.itemID = items.itemID
@@ -43,7 +46,8 @@ local query_items = [[
       INNER JOIN itemDataValues as parentItemDataValues ON parentItemDataValues.valueID = parentItemData.valueID
       INNER JOIN fields ON fields.fieldID = parentItemData.fieldID
       INNER JOIN itemTypes ON itemTypes.itemTypeID = items.itemTypeID
-    ]]
+      LEFT JOIN itemAttachments ON items.itemID = itemAttachments.parentItemID AND itemAttachments.contentType = 'application/pdf'
+]]
 
 local query_creators = [[
     SELECT
@@ -83,6 +87,13 @@ function M.get_items()
     end
     raw_items[v.key][v.fieldName] = v.value
     raw_items[v.key].itemType = v.typeName
+    if v.attachment_path then
+      raw_items[v.key].attachment = {
+        path = v.attachment_path,
+        content_type = v.attachment_content_type,
+        link_mode = v.attachment_link_mode,
+      }
+    end
   end
   for _, v in pairs(sql_creators) do
     if raw_items[v.key] ~= nil then

--- a/lua/zotero/database.lua
+++ b/lua/zotero/database.lua
@@ -83,23 +83,26 @@ function M.get_items()
 
   for _, v in pairs(sql_items) do
     if raw_items[v.key] == nil then
-      raw_items[v.key] = { creators = {} }
+      raw_items[v.key] = { creators = {}, attachment = {} }
     end
     raw_items[v.key][v.fieldName] = v.value
     raw_items[v.key].itemType = v.typeName
     if v.attachment_path then
-      raw_items[v.key].attachment = {
-        path = v.attachment_path,
-        content_type = v.attachment_content_type,
-        link_mode = v.attachment_link_mode,
-      }
+      raw_items[v.key].attachment.path = v.attachment_path
+      raw_items[v.key].attachment.content_type = v.attachment_content_type
+      raw_items[v.key].attachment.link_mode = v.attachment_link_mode
+    end
+    if v.fieldName == 'DOI' then
+      raw_items[v.key].DOI = v.value
     end
   end
+
   for _, v in pairs(sql_creators) do
     if raw_items[v.key] ~= nil then
       raw_items[v.key].creators[v.orderIndex + 1] = { firstName = v.firstName, lastName = v.lastName, creatorType = v.creatorType }
     end
   end
+
   for key, item in pairs(raw_items) do
     local citekey = bbt_citekeys[key]
     if citekey ~= nil then

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -67,7 +67,8 @@ local function open_pdf(attachment)
     return
   end
 
-    if file_path ~= '' then
+  -- if vim.fn.filereadable(file_path) == 1 then
+  if file_path ~= '' then
     local open_cmd
     if vim.fn.has 'win32' == 1 or vim.fn.has 'win64' == 1 then
       open_cmd = 'start'
@@ -79,7 +80,6 @@ local function open_pdf(attachment)
       vim.notify('Unsupported OS', vim.log.levels.ERROR)
       return
     end
-
     vim.fn.system(open_cmd .. ' ' .. vim.fn.shellescape(file_path))
   else
     vim.notify('File not found: ' .. file_path, vim.log.levels.ERROR)
@@ -147,10 +147,13 @@ local function make_entry(pre_entry)
   year = extract_year(year)
   pre_entry.year = year
 
-  local display_value = string.format('%s, %s) %s', last_name, year, pre_entry.title)
+  local pdf_icon = pre_entry.attachment and pre_entry.attachment.path and ' ' or '  '
+  local display_value = string.format('%s%s, %s) %s', pdf_icon, last_name, year, pre_entry.title)
+
   local highlight = {
-    { { 0, #last_name + #year + 3 }, 'Comment' },
-    { { #last_name + 2, #year + #last_name + 2 }, '@markup.underline' },
+    { { 0, #pdf_icon }, 'SpecialChar' },
+    { { #pdf_icon, #pdf_icon + #last_name + #year + 3 }, 'Comment' },
+    { { #pdf_icon + #last_name + 2, #pdf_icon + #year + #last_name + 2 }, '@markup.underline' },
   }
 
   local function make_display(_)

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -67,8 +67,20 @@ local function open_pdf(attachment)
     return
   end
 
-  if vim.fn.filereadable(file_path) == 1 then
-    vim.fn.system('xdg-open ' .. vim.fn.shellescape(file_path))
+    if vim.fn.filereadable(file_path) == 1 then
+    local open_cmd
+    if vim.fn.has 'win32' == 1 or vim.fn.has 'win64' == 1 then
+      open_cmd = 'start'
+    elseif vim.fn.has 'macunix' == 1 then
+      open_cmd = 'open'
+    elseif vim.fn.has 'unix' == 1 then
+      open_cmd = 'xdg-open'
+    else
+      vim.notify('Unsupported OS', vim.log.levels.ERROR)
+      return
+    end
+
+    vim.fn.system(open_cmd .. ' ' .. vim.fn.shellescape(file_path))
   else
     vim.notify('File not found: ' .. file_path, vim.log.levels.ERROR)
   end

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -13,6 +13,7 @@ local default_opts = {
   zotero_db_path = '~/Zotero/zotero.sqlite',
   better_bibtex_db_path = '~/Zotero/better-bibtex.sqlite',
   zotero_storage_path = '~/Zotero/storage',
+  pdf_opener = nil,
   -- specify options for different filetypes
   -- locate_bib can be a string or a function
   ft = {
@@ -62,16 +63,14 @@ local function get_attachment_options(item)
   return options
 end
 
-local function open_url(url)
-  local open_cmd
-  if vim.fn.has 'win32' == 1 then
-    open_cmd = 'start'
-  elseif vim.fn.has 'macunix' == 1 then
-    open_cmd = 'open'
-  else -- Assume Unix
-    open_cmd = 'xdg-open'
+local function open_url(url, file_type)
+  if file_type == 'pdf' and M.config.pdf_opener then
+    -- Use the custom PDF opener if specified
+    vim.fn.system(M.config.pdf_opener .. ' ' .. vim.fn.shellescape(url))
+  else
+    -- Use vim.ui.open for other file types or if no custom PDF opener is set
+    vim.ui.open(url)
   end
-  vim.fn.system(open_cmd .. ' ' .. vim.fn.shellescape(url))
 end
 
 local function open_in_zotero(item_key)
@@ -89,7 +88,7 @@ local function open_attachment(item)
         file_path = zotero_storage .. '/' .. file_path
       end
       if file_path ~= 0 then
-        open_url(file_path)
+        open_url(file_path, 'pdf')
       else
         vim.notify('File not found: ' .. file_path, vim.log.levels.ERROR)
       end

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -64,13 +64,18 @@ local function get_attachment_options(item)
 end
 
 local function open_url(url, file_type)
+  local open_cmd
   if file_type == 'pdf' and M.config.pdf_opener then
     -- Use the custom PDF opener if specified
     vim.fn.system(M.config.pdf_opener .. ' ' .. vim.fn.shellescape(url))
-  else
-    -- Use vim.ui.open for other file types or if no custom PDF opener is set
-    vim.ui.open(url)
+  elseif vim.fn.has 'win32' == 1 then
+    open_cmd = 'start'
+  elseif vim.fn.has 'macunix' == 1 then
+    open_cmd = 'open'
+  else -- Assume Unix
+    open_cmd = 'xdg-open'
   end
+  vim.fn.system(open_cmd .. ' ' .. vim.fn.shellescape(url))
 end
 
 local function open_in_zotero(item_key)
@@ -88,12 +93,12 @@ local function open_attachment(item)
         file_path = zotero_storage .. '/' .. file_path
       end
       if file_path ~= 0 then
-        open_url(file_path, 'pdf')
+        open_url(file_path)
       else
         vim.notify('File not found: ' .. file_path, vim.log.levels.ERROR)
       end
     elseif choice.type == 'doi' then
-      open_url(choice.url)
+      vim.ui.open(choice.url)
     elseif choice.type == 'zotero' then
       open_in_zotero(choice.key)
     end

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -67,7 +67,7 @@ local function open_pdf(attachment)
     return
   end
 
-    if vim.fn.filereadable(file_path) == 1 then
+    if file_path ~= '' then
     local open_cmd
     if vim.fn.has 'win32' == 1 or vim.fn.has 'win64' == 1 then
       open_cmd = 'start'


### PR DESCRIPTION
## New Features

### PDF and DOI Integration

This pull request to telescope-zotero.nvim adds the ability to open Entries in Zotero, PDF attachments and DOI links directly from the Telescope picker. 

- **PDF Opening**: For entries with attached PDFs, you can now open the PDF file directly from the picker.
- **DOI Link Opening**: If an entry has a DOI but no PDF, you can open the DOI link in your default web browser.
- **Open in Zotero**: Directly open entry in Zotero
- **Multiple Attachment Handling**: For entries with both PDF and DOI available, you can choose which one to open.

### Visual Indicators

The picker now includes visual indicators to show the availability of attachments:

-  : Entry has a PDF attachment
- 🌐 : Entry has a DOI link
-  : Entry has both PDF and DOI available
-  : Open Entry in Zotero DataBase

### Cross-Platform Compatibility

The plugin now works across different operating systems:

- Windows
- macOS
- Unix-based systems (Linux, BSD, etc.)

## Usage

- Use the default Telescope keybindings to navigate the Zotero library.
- Press `<C-o>` in insert mode or `o` in normal mode to open the attachment:
  - If only a PDF or DOI is available, it will open directly.
  - If both are available, you'll be prompted to choose which one to open.

## Configuration

The plugin now includes additional configuration options, since Zotero can have attachments in the form of URI, stored copies or links to the file:

```lua
require('telescope').setup {
  extensions = {
    zotero = {
      zotero_db_path = "~/path/to/zotero.sqlite",
      better_bibtex_db_path = "~/path/to/better-bibtex.sqlite",
      zotero_storage_path = "~/path/to/zotero/storage",
      -- other existing options...
     pdf_opener = "<your custom opener, e.g., zathura, sioyek, etc>"
    }
  }
}