### PR TITLE
updated bib file fetching strategy

### DIFF
--- a/lua/zotero/bib.lua
+++ b/lua/zotero/bib.lua
@@ -5,6 +5,7 @@ local M = {}
 M.quarto = {}
 M.tex = {}
 M['quarto.cached_bib'] = nil
+M['tex.cached_bib'] = nil
 
 M.locate_quarto_bib = function()
   if M['quarto.cached_bib'] then
@@ -35,23 +36,91 @@ M.locate_quarto_bib = function()
 end
 
 M.locate_tex_bib = function()
-  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  for _, line in ipairs(lines) do
-    -- ignore commented bibliography
-    local comment = string.match(line, '^%%')
-    if not comment then
-      local location = string.match(line, [[\bibliography{[ "']*([^'"\{\}]+)["' ]*}]])
-      if location then
-        return location .. '.bib'
-      end
-      -- checking for biblatex
-      location = string.match(line, [[\addbibresource{[ "']*([^'"\{\}]+)["' ]*}]])
-      if location then
-        -- addbibresource optionally allows you to add .bib
-        return location:gsub('.bib', '') .. '.bib'
+  if M['tex.cached_bib'] then
+    return M['tex.cached_bib']
+  end
+
+  -- Helper function
+  local function scan_lines(lines)
+    for _, line in ipairs(lines) do
+      -- ignore commented bibliography
+      local comment = string.match(line, '^%%')
+      if not comment then
+        local location = string.match(line, [[\bibliography{[ "']*([^'"\{\}]+)["' ]*}]])
+        if location then
+          -- bibliography optionally allows you to add .bib
+          return location:gsub('.bib', '') .. '.bib'
+        end
+        -- checking for biblatex
+        location = string.match(line, [[\addbibresource{[ "']*([^'"\{\}]+)["' ]*}]])
+        if location then
+          -- addbibresource optionally allows you to add .bib
+          return location:gsub('.bib', '') .. '.bib'
+        end
       end
     end
   end
+
+  -- Scan current buffer
+  local buf_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local bib = scan_lines(buf_lines)
+  if bib then
+    M._bib_path = bib
+    M['tex.cached_bib'] = bib
+    return bib
+  end
+
+  -- Look for TEX root comment in current buffer
+  for _, line in ipairs(buf_lines) do
+    local buf_dir = vim.fn.expand '%:p:h'
+    local root = line:match '^%%!TEX%s+root%s*=%s*(.+.tex)'
+
+    if root then
+      local sep = package.config:sub(1, 1)
+
+      local clean_root = root:gsub('^[/\\]+', ''):gsub('[/\\]+$', ''):gsub('[/\\]', sep)
+
+      local root_abs = buf_dir .. sep .. clean_root
+      if vim.fn.filereadable(root_abs) == 1 then
+        -- Read root file and scan
+        local root_lines = vim.fn.readfile(root_abs)
+        bib = scan_lines(root_lines)
+        if bib then
+          M._bib_path = bib
+          M['tex.cached_bib'] = bib
+          return bib
+        end
+        break
+      end
+    end
+  end
+
+  -- Glob for .bib files in cwd
+  local cwd = vim.fn.getcwd()
+  local files = vim.fn.globpath(cwd, '**/*.bib', false, true)
+  if #files == 1 then
+    M._bib_path = files[1]
+    M['tex.cached_bib'] = files[1]
+    return files[1]
+  elseif #files > 1 then
+    vim.ui.select(files, { prompt = 'Select bibliography file:' }, function(choice)
+      if choice then
+        M._bib_path = choice
+        M['tex.cached_bib'] = choice
+        return
+      end
+    end)
+  end
+
+  -- Last resort: prompt explicitly
+  local manual = vim.fn.input('Path to bibliography file: ', '', 'file')
+  if manual and manual ~= '' then
+    M._bib_path = manual
+    M['tex.cached_bib'] = manual
+    return manual
+  end
+
+  return nil
 end
 
 M.entry_to_bib_entry = function(entry)


### PR DESCRIPTION
Attempts to resolve #30 

This is only for latex, since I have no experience working with quarto, but the concepts should easily transfer over if someone can test and implement them. 

The strategy now
- First looks for the `\bibliography` or `\addbibresource` commands in the current buffer
  - Worth noting here that `\bibliography` also allows appending .bib at the end of the file (Tested on overleaf and miktex)
- Next, checks if the current buffer has a `%!TEX root = *.tex` style comment, which would define the relative path of the main.tex file to the current buffer, and if that file is valid, searches that file for `\bibliography` or `\addbibresource` commands.
  - Many modular latex projects have such a command, and it's probably worth actually elevating this to a user config option (with the current regex as fallback).
- Next, searches for all .bib files in the current working directory
  - If there are multiple, it will present a choice list to the user
- Finally just attempts to ask the user for the direct path as a final resort.

Please note **_I have absolutely no experience whatsoever with lua and neovim plugins!_** 
I've tried to write the best possible implementation I could with just googling and some LLM help 😅.
I tested all the options implemented here the best I could on my local setup, but I have no clue if there are any edge cases that I could have possibly missed here.
I've also tried to make sure it's operating system agnostic, but I could have missed something there as well. 

Please let me know if there are any fixes/changes I can make, or feel free to modify stuff as well! Thanks for the amazing plugin!
