### PR TITLE
feat: add support for typst

### DIFF
--- a/lua/zotero/bib.lua
+++ b/lua/zotero/bib.lua
@@ -96,6 +96,17 @@ M.locate_tex_bib = function()
   end
 end
 
+M.locate_typst_bib = function()
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  for _, line in ipairs(lines) do
+    local location = line:match("^#bibliography%((.+)%)")
+    if location then
+      return location
+    end
+  end
+  return "references.bib"
+end
+
 M.entry_to_bib_entry = function(entry)
   local bib_entry = '@'
   local item = entry.value

--- a/lua/zotero/bib.lua
+++ b/lua/zotero/bib.lua
@@ -101,7 +101,7 @@ M.locate_typst_bib = function()
   for _, line in ipairs(lines) do
     local location = line:match("^#bibliography%((.+)%)")
     if location then
-      return location
+      return location:sub(2,-2)
     end
   end
   return "references.bib"

--- a/lua/zotero/init.lua
+++ b/lua/zotero/init.lua
@@ -41,6 +41,12 @@ local default_opts = {
       end,
       locate_bib = bib.locate_asciidoc_bib,
     },
+    typst = {
+      insert_key_formatter = function(citekey)
+        return '@' .. citekey
+      end,
+      locate_bib = bib.locate_typst_bib,
+    },
     -- fallback for unlisted filetypes
     default = {
       insert_key_formatter = function(citekey)


### PR DESCRIPTION
This PR adds support for adding citations using the plugin to files with the `typst` filetype. By defaults, it locates the references bib file using the `#bibliography` function call, otherwise it defaults to `references.bib`.