### PR TITLE
feat: improve telescope picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Add to your telescope config, e.g. in lazy.nvim
 
 Default options:
 ```lua
+---@type Zotero.Configuration
 {
   -- File system options
   zotero_db_path        = '~/Zotero/zotero.sqlite',

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 List references from your local [Zotero](https://www.zotero.org/) library and add them to a bib file.
 
+<div align="center">
+<img width="912" height="740" alt="Telescope zotero" src="https://github.com/user-attachments/assets/ea7e84c9-3d36-467c-88e9-39bb0f4d9bb5" />
+  <p><em>Telescope zotero picker</em></p>
+</div>
+
+<div align="center">
+  <img width="912" height="740" alt="Open entry propmt" src="https://github.com/user-attachments/assets/db759bfb-6239-4d39-b797-9e19d99967c2" />
+  <p><em>Open entry prompt (Control-O over the current entry)</em></p>
+</div>
+
 This does **not** provide autompletion in the document itself, as this is handled by https://github.com/jmbuhr/cmp-pandoc-references
 for entries already in `references.bib`. The intended workflow separates already used references from new ones imported from Zotero
 via this new plugin.
@@ -102,7 +112,6 @@ opts = {
   },
 }
 ```
-
 
 For adding support for a specific filetype, please open a PR request.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,67 @@ Add to your telescope config, e.g. in lazy.nvim
 },
 ```
 
-Default options: <https://github.com/jmbuhr/telescope-zotero.nvim/blob/main/lua/zotero/init.lua#L12>
+Default options:
+```lua
+{
+  -- File system options
+  zotero_db_path        = '~/Zotero/zotero.sqlite',
+  better_bibtex_db_path = '~/Zotero/better-bibtex.sqlite',
+  zotero_storage_path   = '~/Zotero/storage',
+  pdf_opener            = nil,
+
+  -- Picker options
+  picker = {
+    with_icons = true,
+    hlgroups = {
+      icons       = 'SpecialChar',
+      author_date = 'Comment',
+      title       = 'Title',
+    },
+  },
+
+  -- Filetype options (refer to next section)
+  ft = { ... }
+}
+```
+
+## Supported filetypes
+
+`telescope-zotero.nvim` supports formatting and references detection for the following
+filetypes:
+
+| Filetype | Format | Reference (fallback) |
+|----------|--------|---------------------|
+| Quarto | `bibliography: <path>` | N/A |
+| AsciiDoc | `:bibliography-database: <path>` or `:bibtex-file: <path>` | `references.bib` |
+| TeX/LaTeX | `\bibliography{<path>}` or `\addbibresource{<path>}` | N/A |
+| Typst | `#bibliography(<path>)` | `references.bib` |
+| Org | `#+BIBLIOGRAPHY: <path>` or `#+bibliography: <path>` | `references.bib` |
+
+For adding support for your filetype, you can add it to the `ft` table found in the options.
+Entries in the table accept two parameters:
+
+- `insert_key_formatter`, a function that converts a `citekey` into a citation.
+- `locate_bib`, a function that locates the references bib file used in the current buffer.
+
+For example, we can add support for `text` filetype as follows:
+```lua
+opts = {
+  fts = {
+    text = {
+      insert_key_formatter = function(citekey)
+        return '[citation:' .. citekey .. ']'
+      end,
+      locate_bib = function()
+        -- You function that locates the reference file in the current buffer
+      end
+    },
+  },
+}
+```
+
+
+For adding support for a specific filetype, please open a PR request.
 
 ## Demo
 
@@ -55,7 +115,7 @@ Video (https://www.youtube.com/watch?v=_o5SkTW67do):
 ## Inspiration
 
 This extension is inspired by the following plugins that all do an amazing job, but not quite what I need.
-Depending on your needs, you should have a look at those:
+Depending on your needs, you should take a look at those:
 
 - [zotcite](https://github.com/jalvesaq/zotcite) provides omnicompletion for zotero items in Quarto, Rmarkdown etc., but requires additional dependencies and uses a custom pandoc lua filter instead of a references.bib file
 - [zotex.nvim](https://github.com/tiagovla/zotex.nvim) is very close, but as a nvim-cmp completion source, which doesn't fit


### PR DESCRIPTION
This PR intends to improve the Telescope picker in order to tackle 2 problems with the old version:

- Improve legibility without using highlight groups
- Accept user defined highlighting

For initial discussion, refer to #38.

The new version looks like this (with the default colorscheme):
| | `bg=light` | `bg=dark` |
|:-|:-:|:-:|
| With icons | <img width="912" height="740" alt="Screenshot 2025-08-18 at 01 58 59" src="https://github.com/user-attachments/assets/9f2caed8-4d04-4d3e-a942-ae3e8f56f71a" /> | <img width="912" height="740" alt="Screenshot 2025-08-18 at 01 58 38" src="https://github.com/user-attachments/assets/4e0bff7e-fd89-4223-9100-ba04f43f3363" /> |
| Without icons | <img width="912" height="740" alt="Screenshot 2025-08-18 at 02 03 17" src="https://github.com/user-attachments/assets/780381cc-68bb-4fd7-8b47-dc7c99a6b7f4" /> | <img width="912" height="740" alt="Screenshot 2025-08-18 at 02 03 33" src="https://github.com/user-attachments/assets/39f76765-1c18-4d4d-af77-c39fea2dc4bb" /> |

Changes for the example shown in #38:

- Added user defined highlight groups
- Removed spaces between icons

I did some work adding documentation and type annotations, since this are handy for both maintainers and users. 

LMKWYT